### PR TITLE
Fixed failing debounce test and changed its example in the documentation

### DIFF
--- a/lib/functional_listener.dart
+++ b/lib/functional_listener.dart
@@ -91,7 +91,7 @@ extension FunctionaListener<T> on ValueListenable<T> {
   /// want or can handle them all [debounce] can help you.
   /// If you add a [debounce] to your listenable processing pipeline the returned
   /// `ValueListenable` will not emit an updated value before at least
-  /// [timpeout] time has passed since the last value change. All value changes
+  /// [timeOut] time has passed since the last value change. All value changes
   /// before will be discarded.
   ///
   /// ATTENTION: If you use [debounce] inside the Widget tree in combination with
@@ -107,17 +107,12 @@ extension FunctionaListener<T> on ValueListenable<T> {
   ///     .listen((x, _) => print(x));
   ///
   /// listenable.value = 42;
-  /// await Future.delayed(const Duration(milliseconds: 100));
   /// listenable.value = 43;
-  /// await Future.delayed(const Duration(milliseconds: 100));
   /// listenable.value = 44;
-  /// await Future.delayed(const Duration(milliseconds: 350));
   /// listenable.value = 45;
-  /// await Future.delayed(const Duration(milliseconds: 550));
-  /// listenable.value = 46;
-  ///
+  /// await Future.delayed(const Duration(milliseconds: 500));
   /// ```
-  ///  will print out 42,45,46
+  ///  will print out 45
   ///
   ValueListenable<T> debounce(Duration timeOut) {
     return DebouncedValueNotifier(this.value, this, timeOut);

--- a/test/listenable_pipe_test.dart
+++ b/test/listenable_pipe_test.dart
@@ -90,16 +90,12 @@ void main() {
         .listen((x, _) => destValues.add(x));
 
     listenable.value = 42;
-    await Future.delayed(const Duration(milliseconds: 100));
     listenable.value = 43;
-    await Future.delayed(const Duration(milliseconds: 100));
     listenable.value = 44;
-    await Future.delayed(const Duration(milliseconds: 350));
     listenable.value = 45;
-    await Future.delayed(const Duration(milliseconds: 550));
-    listenable.value = 46;
+    await Future.delayed(const Duration(milliseconds: 500));
 
-    expect(destValues, [42, 45, 46]);
+    expect(destValues, [45]);
   });
 
   test('combineLatest Test', () {


### PR DESCRIPTION
Example code from the doc and test
```dart
final listenable = ValueNotifier<int>(0);
listenable
    .debounce(const Duration(milliseconds: 500))
    .listen((x, _) => print(x));

listenable.value = 42;
await Future.delayed(const Duration(milliseconds: 100));
listenable.value = 43;
await Future.delayed(const Duration(milliseconds: 100));
listenable.value = 44;
await Future.delayed(const Duration(milliseconds: 350));
listenable.value = 45;
await Future.delayed(const Duration(milliseconds: 550));
listenable.value = 46;
// will print out 42 ,45,46
```


But after the execution of the above code, only `45` should be printed out and it does too, because whenever we assign a new value to `listenable.value` it will be overriding the old value after the debounce time is ended. If we want to print all values, in this example 42, 43, 44, 45, and 46, we need to await for `>=` debounce time which is (500 in this case) after each assignment. So the code will be like


```dart
final listenable = ValueNotifier<int>(0);
listenable
    .debounce(const Duration(milliseconds: 500))
    .listen((x, _) => print(x));

listenable.value = 42;
await Future.delayed(const Duration(milliseconds: 500));
listenable.value = 43;
await Future.delayed(const Duration(milliseconds: 500));
listenable.value = 44;
await Future.delayed(const Duration(milliseconds: 500));
listenable.value = 45;
await Future.delayed(const Duration(milliseconds: 500));
listenable.value = 46;
// will print out 42, 43, 44, 45,46
```