### PR TITLE
Fix double chain subscriptions.

### DIFF
--- a/test/listenable_pipe_test.dart
+++ b/test/listenable_pipe_test.dart
@@ -264,6 +264,32 @@ void main() {
     expect(val, 42);
     expect(callCount, 2);
   });
+
+  test('no double chain subscriptions', () {
+    final notifier = CustomValueNotifier<int>(0, mode: CustomNotifierMode.always);
+    int callCount = 0;
+    notifier.listen((v, _) {
+      callCount++;
+    });
+
+    int chainCallCount = 0;
+    final mapNotifier = notifier.map((v) {
+      chainCallCount++;
+      return v + 1;
+    });
+
+    int mapCallCount = 0;
+    mapNotifier.listen((v, _) {
+      mapCallCount++;
+    });
+
+    notifier.value = 1;
+
+    expect(callCount, 1);
+    expect(mapNotifier.value, 2);
+    expect(mapCallCount, 1);
+    expect(chainCallCount, 2); // 1 on init, 1 after notifier.value = 1;
+  });
 }
 
 class StringIntWrapper {


### PR DESCRIPTION
Currently if you use `map`() (and probably other functions) there are 2 listeners added to the parent listenable
One in constructor, and another one as soon as mapped listener gets it's own subscription in `addListener` (the check is for `hasListeners` which is false at the time, but the chain is already set up).
After mapped subscription is removed, the second chain listener is properly removed but the first one remains.
This PR fixes the issue described above.